### PR TITLE
POSIX-compatible shell invocation

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -32,7 +32,7 @@ table.insert(menu_gen.all_menu_dirs, string.format("%s/.nix-profile/share/applic
 -- Remove non existent paths in order to avoid issues
 local existent_paths = {}
 for k,v in pairs(menu_gen.all_menu_dirs) do
-    if os.execute(string.format("ls %s &> /dev/null", v)) then
+    if os.execute(string.format("ls %s >/dev/null 2>&1", v)) then
         table.insert(existent_paths, v)
     end
 end


### PR DESCRIPTION
&> is a bashism which doesn't work with different shells
(like dash, which is default in Debian).