### PR TITLE
Fixing the .rockspec 'source.tag' definition.

### DIFF
--- a/awesome-freedesktop-scm-1.rockspec
+++ b/awesome-freedesktop-scm-1.rockspec
@@ -1,8 +1,8 @@
 package = "awesome-freedesktop"
 version = "scm-1"
 source = {
-   url = "https://github.com/lcpz/awesome-freedesktop",
-   tag = "scm-1`"
+   url = "git://github.com/lcpz/awesome-freedesktop",
+   tag = "master",
 }
 description = {
    summary = "Freedesktop.org menu and desktop icons support for Awesome WM",


### PR DESCRIPTION
To fix #15, we change the source.tag definition in the rockspec from 'scm-1' to master. Now, instead of searching for a branch/tag in the repository called 'scm-1', it will by default use the code from the master branch.