### PR TITLE
Remove hardcoded NixOS desktop application path

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -18,9 +18,6 @@ local icon_theme = require("menubar.icon_theme")
 
 local io, pairs, string, table, os = io, pairs, string, table, os
 
--- Add support for NixOS systems too
-table.insert(menu_gen.all_menu_dirs, string.format("%s/.nix-profile/share/applications", os.getenv("HOME")))
-
 -- Expecting a wm_name of awesome omits too many applications and tools
 menu_utils.wm_name = ""
 


### PR DESCRIPTION
As noted in https://github.com/lcpz/awesome-freedesktop/issues/20, after the support for XDG_DATA_DIRS was added to Awesome menubar, there is no more need to manually add this path to `menu_gen.all_menu_dirs`