### PR TITLE
Fixes positioning of icons across multiple screens for desktop.lua

### DIFF
--- a/desktop.lua
+++ b/desktop.lua
@@ -55,7 +55,7 @@ local desktop = {
 local mime_types = {}
 
 -- Icons positioning
-local desktop_current_pos = {}
+desktop.current_pos = {}
 
 -- @return iterator on input pipe
 local function pipelines(...)
@@ -74,18 +74,19 @@ end
 -- @param onclick function to execute on click
 function desktop.add_single_icon(args, label, icon, onclick)
     local s = args.screen
+    local dcp = desktop.current_pos
 
     -- define icon dimensions and position
-    if not desktop_current_pos[s] then
-        desktop_current_pos[s] = { x = (screen[s].geometry.x + args.iconsize.width + args.margin.x), y = 40 }
+    if not dcp[s] then
+        dcp[s] = { x = (screen[s].geometry.x + args.iconsize.width + args.margin.x), y = screen[s].geometry.y + 40 + args.margin.y  }
     end
 
-    local totheight = (icon and args.iconsize.height or 0) + (label and args.labelsize.height or 0)
-    if totheight == 0 then return end
+    local tot_height = (icon and args.iconsize.height or 0) + (label and args.labelsize.height or 0)
+    if tot_height == 0 then return end
 
-    if desktop_current_pos[s].y + totheight > screen[s].geometry.height - 40 then
-        desktop_current_pos[s].x = desktop_current_pos[s].x + args.labelsize.width + args.iconsize.width + args.margin.x
-        desktop_current_pos[s].y = 40
+    if dcp[s].y + tot_height > screen[s].geometry.y + screen[s].geometry.height - 40 - args.margin.y then
+        dcp[s].x = dcp[s].x + args.labelsize.width + args.iconsize.width + args.margin.x
+        dcp[s].y = 40 + args.margin.y
     end
 
     local common = { screen = s, bg = "#00000000", visible = true, type = "desktop" }
@@ -94,8 +95,8 @@ function desktop.add_single_icon(args, label, icon, onclick)
     if icon then
         common.width = args.iconsize.width
         common.height = args.iconsize.height
-        common.x = desktop_current_pos[s].x
-        common.y = desktop_current_pos[s].y
+        common.x = dcp[s].x
+        common.y = dcp[s].y
 
         icon = wibox.widget {
             image = icon,
@@ -108,15 +109,15 @@ function desktop.add_single_icon(args, label, icon, onclick)
         icon_container = wibox(common)
         icon_container:set_widget(icon)
 
-        desktop_current_pos[s].y = desktop_current_pos[s].y + args.iconsize.height + 5
+        dcp[s].y = dcp[s].y + args.iconsize.height + 5
     end
 
     -- create label container
     if label then
         common.width = args.labelsize.width
         common.height = args.labelsize.height
-        common.x = desktop_current_pos[s].x - (args.labelsize.width/2) + args.iconsize.width/2
-        common.y = desktop_current_pos[s].y
+        common.x = dcp[s].x - (args.labelsize.width/2) + args.iconsize.width/2
+        common.y = dcp[s].y
 
         caption = wibox.widget {
             text          = label,
@@ -132,7 +133,11 @@ function desktop.add_single_icon(args, label, icon, onclick)
         caption_container:set_widget(caption)
     end
 
-    desktop_current_pos[s].y = desktop_current_pos[s].y + args.labelsize.height + args.margin.y
+    dcp[s].y = dcp[s].y + args.labelsize.height + args.margin.y
+
+    desktop.current_pos = dcp
+
+    return dcp
 end
 
 -- Adds base icons (This PC, Trash, etc) to desktop

--- a/desktop.lua
+++ b/desktop.lua
@@ -78,15 +78,15 @@ function desktop.add_single_icon(args, label, icon, onclick)
 
     -- define icon dimensions and position
     if not dcp[s] then
-        dcp[s] = { x = (screen[s].geometry.x + args.iconsize.width + args.margin.x), y = screen[s].geometry.y + 40 + args.margin.y  }
+        dcp[s] = { x = (screen[s].geometry.x + args.iconsize.width + args.margin.x), y = screen[s].geometry.y + 20 + args.margin.y  }
     end
 
     local tot_height = (icon and args.iconsize.height or 0) + (label and args.labelsize.height or 0)
     if tot_height == 0 then return end
 
-    if dcp[s].y + tot_height > screen[s].geometry.y + screen[s].geometry.height - 40 - args.margin.y then
+    if dcp[s].y + tot_height > screen[s].geometry.y + screen[s].geometry.height - 20 - args.margin.y then
         dcp[s].x = dcp[s].x + args.labelsize.width + args.iconsize.width + args.margin.x
-        dcp[s].y = 40 + args.margin.y
+        dcp[s].y = 20 + args.margin.y
     end
 
     local common = { screen = s, bg = "#00000000", visible = true, type = "desktop" }


### PR DESCRIPTION

Icons were behaving strangely across multiple monitors, although I noticed it worked on the one at 0,0 

Seems there was a mismatch in global positioning. 
I fixed the mismatch. 

Now they work across my all my screens. :D

Additionally:
- Not sure what variable "totheight" is named after, but it was giving me temporary dyslexia so I renamed it to "tot_height".
- I re-adjusted the 40 hard-coded margin to 20 to account for adding in an extra margin using the margin.y parameter. 




