### PR TITLE
Fix search for desktop files

### DIFF
--- a/desktop.lua
+++ b/desktop.lua
@@ -191,7 +191,7 @@ end
 -- @return files table with found entries
 function desktop.parse_dirs_and_files(dir)
     local files = {}
-    local paths = pipelines('find '..dir..' -maxdepth 1 -type d | tail -1')
+    local paths = pipelines('find '..dir..' -maxdepth 1 -type d |sort|tail -n +1')
     for path in paths do
         if path:match("[^/]+$") then
             local file = {}


### PR DESCRIPTION
The original section did not give me a list of desktop files to be generated. 
Instead it only returned the last one. 

I changed the command `tail -1` ; which only returns the last item in a list. 

The option `tail -n +1` ensures that entries from the first line down are included. 
This may seem redundant, but I left it as an example for future tinkerers. 
And also because the widgets do not provide a drag and drop feature for items on the desktop; as of yet. 

The option `tail -n +2` would hide the Desktop folder, I leave this for future imaginings.

I also added the `sort` command to sort entries after generating a list. 
