### PR TITLE
Export missing files in awesome-freedesktop-scm-1.rockspec

### DIFF
--- a/awesome-freedesktop-scm-1.rockspec
+++ b/awesome-freedesktop-scm-1.rockspec
@@ -15,5 +15,9 @@ dependencies = {
 supported_platforms = { "linux" }
 build = {
    type = "builtin",
-   modules = { freedesktop = "init.lua" }
+   modules = {
+    ["freedesktop"] = "init.lua",
+    ["freedesktop.menu"] = "menu.lua",
+    ["freedesktop.desktop"] = "desktop.lua",
+   }
 }


### PR DESCRIPTION
I've been trying to use this as a dependency via luarocks but only the init file is being exported.
 
```
$ ls /usr/share/lua/*/freedesktop/
/usr/share/lua/5.3/freedesktop/:
init.lua

/usr/share/lua/5.4/freedesktop/:
init.lua
```
Not even locally:

```
$ ls .luarocks/share/lua/5.4/freedesktop/
init.lua
```

which ofc makes awesome really sad:

![main](https://github.com/user-attachments/assets/eae88aee-9971-4d44-9381-bb44d543bab7)
